### PR TITLE
Update $php_version

### DIFF
--- a/puppet/manifests/sections/php.pp
+++ b/puppet/manifests/sections/php.pp
@@ -1,4 +1,4 @@
-$php_version = '5.4.39-1+deb.sury.org~precise+2'
+$php_version = '5.4.40+real-1+deb.sury.org~precise+4'
 
 include php
 include apt


### PR DESCRIPTION
Updating PHP version to $php_version = '5.4.40+real-1+deb.sury.org~precise+4' to prevent:

Version '5.4.39-1+deb.sury.org~precise+2' for 'php5' was not found
