### PR TITLE
tweaks wp::command name to solve dupe issue

### DIFF
--- a/puppet/manifests/sections/talk-performance.pp
+++ b/puppet/manifests/sections/talk-performance.pp
@@ -52,7 +52,7 @@ wp::command { 'post create stampede':
   require  => Wp::Command['theme activate performance'],
 }
 
-wp::command { 'post create stampede':
+wp::command { 'post create stampede ads':
   command  => 'post create --post_type=page --post_title="Ads" --post_status=publish --post_name=ads',
   location => '/srv/www/performance',
   require  => Wp::Command['theme activate performance'],


### PR DESCRIPTION
same as https://github.com/2b6047ed4228114a60cd5176d8eb0053748ef00/vip-workshop-vm-2015/pull/2 but with a feature branch for a clean merge separate from https://github.com/2b6047ed4228114a60cd5176d8eb0053748ef00/vip-workshop-vm-2015/pull/4

On a fresh provision, I believe a user will run into a "cannot redefine" error due to dupe names for `puppet/manifests/sections/talk-performance.pp` commands https://github.com/2b6047ed4228114a60cd5176d8eb0053748ef00/vip-workshop-vm-2015/blob/master/puppet/manifests/sections/talk-performance.pp#L49 and https://github.com/2b6047ed4228114a60cd5176d8eb0053748ef00/vip-workshop-vm-2015/blob/master/puppet/manifests/sections/talk-performance.pp#L55

This second command was added in https://github.com/2b6047ed4228114a60cd5176d8eb0053748ef00/vip-workshop-vm-2015/commit/2e11c0757a649e29374345de39203fe68520a3b6#diff-525bdbcde5e51b105601606c342ca6aa

The simple fix is to make the names different, which I've done for myself and in the commit here by appending "ads" to the second command. 

```

$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'precise32' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Adding box 'precise32' (v0) for provider: virtualbox
    default: Downloading: http://files.vagrantup.com/precise32.box
==> default: Successfully added box 'precise32' (v0) for 'virtualbox'!
==> default: Importing base box 'precise32'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: vip-workshop-vm-2015_default_1430807711298_365
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 9200 => 9200 (adapter 1)
    default: 9300 => 9300 (adapter 1)
    default: 5601 => 5601 (adapter 1)
    default: 22 => 2222 (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
    default: Warning: Remote connection disconnect. Retrying...
    default: Warning: Remote connection disconnect. Retrying...
    default: Warning: Remote connection disconnect. Retrying...
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if its present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 4.2.0
    default: VirtualBox Version: 4.3
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
    default: /srv => /Users/mac/Code/vip-workshop-vm-2015
    default: /vagrant => /Users/mac/Code/vip-workshop-vm-2015
    default: /home/vagrant/www => /Users/mac/Code/vip-workshop-vm-2015/www
    default: /home/vagrant/.talks => /Users/mac/Code/vip-workshop-vm-2015/talks
    default: /tmp/vagrant-puppet/modules-aef4e525aa421abd2b4bdf1d7921253e => /Users/mac/Code/vip-workshop-vm-2015/puppet/modules
    default: /tmp/vagrant-puppet/manifests-846018e2aa141a5eb79a64b4015fc5f3 => /Users/mac/Code/vip-workshop-vm-2015/puppet/manifests
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: stdin: is not a tty
==> default: Package `puppet' is not installed and no info is available.
==> default: Use dpkg --info (= dpkg-deb --info) to examine archive files,
==> default: and dpkg --contents (= dpkg-deb --contents) to list their contents.
==> default: Ign http://security.ubuntu.com precise-security InRelease
==> default: Ign http://us.archive.ubuntu.com precise InRelease
==> default: Ign http://us.archive.ubuntu.com precise-updates InRelease
==> default: Ign http://us.archive.ubuntu.com precise-backports InRelease
==> default: Get:1 http://security.ubuntu.com precise-security Release.gpg [198 B]
==> default: Hit http://us.archive.ubuntu.com precise Release.gpg
==> default: Get:2 http://security.ubuntu.com precise-security Release [54.3 kB]
==> default: Get:3 http://us.archive.ubuntu.com precise-updates Release.gpg [198 B]
==> default: Get:4 http://us.archive.ubuntu.com precise-backports Release.gpg [198 B]
==> default: Hit http://us.archive.ubuntu.com precise Release
==> default: Get:5 http://us.archive.ubuntu.com precise-updates Release [196 kB]
==> default: Get:6 http://us.archive.ubuntu.com precise-backports Release [54.3 kB]
==> default: Hit http://us.archive.ubuntu.com precise/main Sources
==> default: Get:7 http://security.ubuntu.com precise-security/main Sources [128 kB]
==> default: Hit http://us.archive.ubuntu.com precise/restricted Sources
==> default: Hit http://us.archive.ubuntu.com precise/universe Sources
==> default: Hit http://us.archive.ubuntu.com precise/multiverse Sources
==> default: Hit http://us.archive.ubuntu.com precise/main i386 Packages
==> default: Hit http://us.archive.ubuntu.com precise/restricted i386 Packages
==> default: Hit http://us.archive.ubuntu.com precise/universe i386 Packages
==> default: Hit http://us.archive.ubuntu.com precise/multiverse i386 Packages
==> default: Hit http://us.archive.ubuntu.com precise/main TranslationIndex
==> default: Hit http://us.archive.ubuntu.com precise/multiverse TranslationIndex
==> default: Hit http://us.archive.ubuntu.com precise/restricted TranslationIndex
==> default: Hit http://us.archive.ubuntu.com precise/universe TranslationIndex
==> default: Get:8 http://us.archive.ubuntu.com precise-updates/main Sources [489 kB]
==> default: Get:9 http://security.ubuntu.com precise-security/restricted Sources [3,759 B]
==> default: Get:10 http://security.ubuntu.com precise-security/universe Sources [35.6 kB]
==> default: Get:11 http://security.ubuntu.com precise-security/multiverse Sources [1,816 B]
==> default: Get:12 http://security.ubuntu.com precise-security/main i386 Packages [541 kB]
==> default: Get:13 http://security.ubuntu.com precise-security/restricted i386 Packages [8,939 B]
==> default: Get:14 http://security.ubuntu.com precise-security/universe i386 Packages [124 kB]
==> default: Get:15 http://security.ubuntu.com precise-security/multiverse i386 Packages [2,650 B]
==> default: Get:16 http://security.ubuntu.com precise-security/main TranslationIndex [208 B]
==> default: Get:17 http://security.ubuntu.com precise-security/multiverse TranslationIndex [199 B]
==> default: Get:18 http://security.ubuntu.com precise-security/restricted TranslationIndex [202 B]
==> default: Get:19 http://security.ubuntu.com precise-security/universe TranslationIndex [205 B]
==> default: Get:20 http://security.ubuntu.com precise-security/main Translation-en [222 kB]
==> default: Get:21 http://security.ubuntu.com precise-security/multiverse Translation-en [1,299 B]
==> default: Get:22 http://security.ubuntu.com precise-security/restricted Translation-en [2,066 B]
==> default: Get:23 http://security.ubuntu.com precise-security/universe Translation-en [71.2 kB]
==> default: Get:24 http://us.archive.ubuntu.com precise-updates/restricted Sources [7,981 B]
==> default: Get:25 http://us.archive.ubuntu.com precise-updates/universe Sources [113 kB]
==> default: Get:26 http://us.archive.ubuntu.com precise-updates/multiverse Sources [9,413 B]
==> default: Get:27 http://us.archive.ubuntu.com precise-updates/main i386 Packages [935 kB]
==> default: Get:28 http://us.archive.ubuntu.com precise-updates/restricted i386 Packages [13.6 kB]
==> default: Get:29 http://us.archive.ubuntu.com precise-updates/universe i386 Packages [269 kB]
==> default: Get:30 http://us.archive.ubuntu.com precise-updates/multiverse i386 Packages [16.6 kB]
==> default: Get:31 http://us.archive.ubuntu.com precise-updates/main TranslationIndex [10.6 kB]
==> default: Get:32 http://us.archive.ubuntu.com precise-updates/multiverse TranslationIndex [7,613 B]
==> default: Get:33 http://us.archive.ubuntu.com precise-updates/restricted TranslationIndex [7,297 B]
==> default: Get:34 http://us.archive.ubuntu.com precise-updates/universe TranslationIndex [8,333 B]
==> default: Get:35 http://us.archive.ubuntu.com precise-backports/main Sources [5,411 B]
==> default: Get:36 http://us.archive.ubuntu.com precise-backports/restricted Sources [28 B]
==> default: Get:37 http://us.archive.ubuntu.com precise-backports/universe Sources [41.4 kB]
==> default: Get:38 http://us.archive.ubuntu.com precise-backports/multiverse Sources [5,750 B]
==> default: Get:39 http://us.archive.ubuntu.com precise-backports/main i386 Packages [5,484 B]
==> default: Get:40 http://us.archive.ubuntu.com precise-backports/restricted i386 Packages [28 B]
==> default: Get:41 http://us.archive.ubuntu.com precise-backports/universe i386 Packages [43.3 kB]
==> default: Get:42 http://us.archive.ubuntu.com precise-backports/multiverse i386 Packages [5,413 B]
==> default: Get:43 http://us.archive.ubuntu.com precise-backports/main TranslationIndex [202 B]
==> default: Get:44 http://us.archive.ubuntu.com precise-backports/multiverse TranslationIndex [202 B]
==> default: Get:45 http://us.archive.ubuntu.com precise-backports/restricted TranslationIndex [193 B]
==> default: Get:46 http://us.archive.ubuntu.com precise-backports/universe TranslationIndex [205 B]
==> default: Hit http://us.archive.ubuntu.com precise/main Translation-en
==> default: Hit http://us.archive.ubuntu.com precise/multiverse Translation-en
==> default: Hit http://us.archive.ubuntu.com precise/restricted Translation-en
==> default: Hit http://us.archive.ubuntu.com precise/universe Translation-en
==> default: Get:47 http://us.archive.ubuntu.com precise-updates/main Translation-en [393 kB]
==> default: Get:48 http://us.archive.ubuntu.com precise-updates/multiverse Translation-en [9,533 B]
==> default: Get:49 http://us.archive.ubuntu.com precise-updates/restricted Translation-en [2,982 B]
==> default: Get:50 http://us.archive.ubuntu.com precise-updates/universe Translation-en [153 kB]
==> default: Get:51 http://us.archive.ubuntu.com precise-backports/main Translation-en [4,911 B]
==> default: Get:52 http://us.archive.ubuntu.com precise-backports/multiverse Translation-en [4,838 B]
==> default: Hit http://us.archive.ubuntu.com precise-backports/restricted Translation-en
==> default: Get:53 http://us.archive.ubuntu.com precise-backports/universe Translation-en [34.4 kB]
==> default: Fetched 4,045 kB in 13s (292 kB/s)
==> default: Reading package lists...



==> default: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   augeas-lenses debconf-utils facter libaugeas-ruby1.8 libaugeas0 libreadline5
==> default:   libruby libruby1.8 libshadow-ruby1.8 puppet-common ruby ruby1.8
==> default: Suggested packages:
==> default:   augeas-doc ruby-json augeas-tools puppet-el vim-puppet etckeeper
==> default:   ruby-selinux libselinux-ruby1.8 librrd-ruby1.8 ri ruby-dev ruby1.8-examples
==> default:   ri1.8
==> default: Recommended packages:
==> default:   rdoc
==> default: The following NEW packages will be installed:
==> default:   augeas-lenses debconf-utils facter libaugeas-ruby1.8 libaugeas0 libreadline5
==> default:   libruby libruby1.8 libshadow-ruby1.8 puppet puppet-common ruby ruby1.8
==> default: 0 upgraded, 13 newly installed, 0 to remove and 179 not upgraded.
==> default: Need to get 3,200 kB of archives.
==> default: After this operation, 12.5 MB of additional disk space will be used.
==> default: Get:1 http://us.archive.ubuntu.com/ubuntu/ precise/main libreadline5 i386 5.2-11 [123 kB]
==> default: Get:2 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main libruby1.8 i386 1.8.7.352-2ubuntu1.6 [1,782 kB]
==> default: Get:3 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main ruby1.8 i386 1.8.7.352-2ubuntu1.6 [33.8 kB]
==> default: Get:4 http://us.archive.ubuntu.com/ubuntu/ precise/main libruby all 4.8 [4,766 B]
==> default: Get:5 http://us.archive.ubuntu.com/ubuntu/ precise/main libshadow-ruby1.8 i386 1.4.1-8build1 [8,828 B]
==> default: Get:6 http://us.archive.ubuntu.com/ubuntu/ precise/main augeas-lenses all 0.10.0-0ubuntu4 [175 kB]
==> default: Get:7 http://us.archive.ubuntu.com/ubuntu/ precise/main libaugeas0 i386 0.10.0-0ubuntu4 [169 kB]
==> default: Get:8 http://us.archive.ubuntu.com/ubuntu/ precise/main libaugeas-ruby1.8 i386 0.3.0-1.1ubuntu4 [9,490 B]
==> default: Get:9 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main facter all 1.6.5-1ubuntu1.2 [45.3 kB]
==> default: Get:10 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main puppet-common all 2.7.11-1ubuntu2.7 [768 kB]
==> default: Get:11 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main puppet all 2.7.11-1ubuntu2.7 [20.2 kB]
==> default: Get:12 http://us.archive.ubuntu.com/ubuntu/ precise/main debconf-utils all 1.5.42ubuntu1 [54.9 kB]
==> default: Get:13 http://us.archive.ubuntu.com/ubuntu/ precise/main ruby all 4.8 [5,054 B]
==> default: dpkg-preconfigure: unable to re-open stdin: No such file or directory
==> default: Fetched 3,200 kB in 4s (755 kB/s)
==> default: Selecting previously unselected package libreadline5.
==> default: (Reading database ... 
==> default: 29361 files and directories currently installed.)
==> default: Unpacking libreadline5 (from .../libreadline5_5.2-11_i386.deb) ...
==> default: Selecting previously unselected package libruby1.8.
==> default: Unpacking libruby1.8 (from .../libruby1.8_1.8.7.352-2ubuntu1.6_i386.deb) ...
==> default: Selecting previously unselected package ruby1.8.
==> default: Unpacking ruby1.8 (from .../ruby1.8_1.8.7.352-2ubuntu1.6_i386.deb) ...
==> default: Selecting previously unselected package libruby.
==> default: Unpacking libruby (from .../archives/libruby_4.8_all.deb) ...
==> default: Selecting previously unselected package libshadow-ruby1.8.
==> default: Unpacking libshadow-ruby1.8 (from .../libshadow-ruby1.8_1.4.1-8build1_i386.deb) ...
==> default: Selecting previously unselected package augeas-lenses.
==> default: Unpacking augeas-lenses (from .../augeas-lenses_0.10.0-0ubuntu4_all.deb) ...
==> default: Selecting previously unselected package libaugeas0.
==> default: Unpacking libaugeas0 (from .../libaugeas0_0.10.0-0ubuntu4_i386.deb) ...
==> default: Selecting previously unselected package libaugeas-ruby1.8.
==> default: Unpacking libaugeas-ruby1.8 (from .../libaugeas-ruby1.8_0.3.0-1.1ubuntu4_i386.deb) ...
==> default: Selecting previously unselected package facter.
==> default: Unpacking facter (from .../facter_1.6.5-1ubuntu1.2_all.deb) ...
==> default: Selecting previously unselected package puppet-common.
==> default: Unpacking puppet-common (from .../puppet-common_2.7.11-1ubuntu2.7_all.deb) ...
==> default: Selecting previously unselected package puppet.
==> default: Unpacking puppet (from .../puppet_2.7.11-1ubuntu2.7_all.deb) ...
==> default: Selecting previously unselected package debconf-utils.
==> default: Unpacking debconf-utils (from .../debconf-utils_1.5.42ubuntu1_all.deb) ...
==> default: Selecting previously unselected package ruby.
==> default: Unpacking ruby (from .../apt/archives/ruby_4.8_all.deb) ...
==> default: Processing triggers for man-db ...
==> default: Processing triggers for ureadahead ...
==> default: ureadahead will be reprofiled on next reboot
==> default: Setting up libreadline5 (5.2-11) ...
==> default: Setting up libruby1.8 (1.8.7.352-2ubuntu1.6) ...
==> default: Setting up ruby1.8 (1.8.7.352-2ubuntu1.6) ...
==> default: update-alternatives: 
==> default: using /usr/bin/ruby1.8 to provide /usr/bin/ruby (ruby) in auto mode.
==> default: Setting up libruby (4.8) ...
==> default: Setting up libshadow-ruby1.8 (1.4.1-8build1) ...
==> default: Setting up augeas-lenses (0.10.0-0ubuntu4) ...
==> default: Setting up libaugeas0 (0.10.0-0ubuntu4) ...
==> default: Setting up libaugeas-ruby1.8 (0.3.0-1.1ubuntu4) ...
==> default: Setting up facter (1.6.5-1ubuntu1.2) ...
==> default: Setting up puppet-common (2.7.11-1ubuntu2.7) ...
==> default: Setting up puppet (2.7.11-1ubuntu2.7) ...
==> default:  * Starting puppet agent
==> default: puppet not configured to start, please edit /etc/default/puppet to enable
==> default:    ...done.
==> default: Setting up debconf-utils (1.5.42ubuntu1) ...
==> default: Setting up ruby (4.8) ...
==> default: Processing triggers for libc-bin ...
==> default: ldconfig deferred processing now taking place
==> default: Running provisioner: puppet...
==> default: Running Puppet with init.pp...
==> default: stdin: is not a tty
==> default: warning: Could not retrieve fact fqdn
==> default: Duplicate definition: Wp::Command[post create stampede] is already defined in file /tmp/vagrant-puppet/manifests-846018e2aa141a5eb79a64b4015fc5f3/sections/talk-performance.pp at line 53; cannot redefine at /tmp/vagrant-puppet/manifests-846018e2aa141a5eb79a64b4015fc5f3/sections/talk-performance.pp:59 on node precise32
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```
